### PR TITLE
A few small changes to make it usable for me

### DIFF
--- a/BrowserBookmarks.py
+++ b/BrowserBookmarks.py
@@ -400,7 +400,8 @@ class BookmarksChrome(BookmarksManager):
             return []
 
         # bookmarks = r'C:\Users\sven\AppData\Local\Google\Chrome\User Data\Default\bookmarks'
-        fs = open(bookmarks, 'r')
+        encoding = self.settings().get("chrome-bookmarks-encoding")
+        fs = open(bookmarks, 'r', encoding=encoding)
         dataDict = json.load(fs)
         fs.close()
 

--- a/BrowserBookmarks.sublime-settings
+++ b/BrowserBookmarks.sublime-settings
@@ -5,6 +5,7 @@
 	
 	// chrome settings
 	"chrome-bookmarks-file" : null, 				// use this to fore a bookmarks json filepath (if automatic system does not work)
+	"chrome-bookmarks-encoding" : "utf8",			// utf8, cp1252, ...
 
 	// firefox settings
 	"firefox-profile" : "default",					// profile name of firefox, default is "deault"

--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,2 @@
 [
-    { "keys": ["ctrl+b"], "command": "show_bookmarks" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,2 @@
 [
-    { "keys": ["ctrl+b"], "command": "show_bookmarks" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,2 @@
 [
-    { "keys": ["ctrl+b"], "command": "show_bookmarks" }
 ]


### PR DESCRIPTION
I first removed the keyboard shortcut, since it overwrite the standard build-project keyboard shortcut. I usually to define my own shortcuts for plugins so I prefer packages to not define any default short-cuts.

Second, apparently my Chrome bookmarks are encoded in UTF8, so I included an option to define the encoding, otherwise it fails with a UnicodeDecodeError. (Win-7 x64)
